### PR TITLE
Add Shoryuken support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,9 +9,9 @@ Lint/RescueException:
   Exclude:
     - lib/kiev/request_body_filter/json.rb
     - lib/kiev/sidekiq/request_logger.rb
+    - lib/kiev/shoryuken/request_logger.rb
     - lib/kiev/rack/request_logger.rb
     - lib/kiev/json.rb
-    - test/sidekiq_test.rb
 Style/GlobalVars:
   Exclude:
     - test/helper.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ gemfile:
   - gemfiles/que_0.12.3.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
+  - gemfiles/shoryuken_3.1.gemfile
   - gemfiles/sidekiq_4.2.gemfile
   - gemfiles/sinatra_1.4.gemfile
   - gemfiles/sinatra_2.0.gemfile

--- a/gemfiles/shoryuken_3.1.gemfile
+++ b/gemfiles/shoryuken_3.1.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "aws-sdk", "~> 2.0"
+gem "shoryuken", "~> 3.1.0"
+
+gem "rack-test", require: false
+gem "minitest-reporters", require: false
+
+gemspec :path => "../"

--- a/lib/kiev.rb
+++ b/lib/kiev.rb
@@ -4,6 +4,7 @@ require_relative "kiev/base"
 require_relative "kiev/rack" if defined?(Rack)
 require_relative "kiev/railtie" if defined?(Rails)
 require_relative "kiev/sidekiq" if defined?(Sidekiq)
+require_relative "kiev/shoryuken" if defined?(Shoryuken)
 require_relative "kiev/her_ext/client_request_id" if defined?(Faraday)
 require_relative "kiev/httparty" if defined?(HTTParty)
 require_relative "kiev/que/job" if defined?(Que::Job)

--- a/lib/kiev/base.rb
+++ b/lib/kiev/base.rb
@@ -3,6 +3,7 @@
 require "request_store"
 require "ruby_dig"
 require_relative "request_store"
+require_relative "request_logger"
 require_relative "logger"
 require_relative "param_filter"
 require_relative "request_body_filter"

--- a/lib/kiev/context_reader.rb
+++ b/lib/kiev/context_reader.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Kiev
+  # Abstracts common details about reading tracing context
+  # into Kiev's request store. Subclass and override #[] to
+  # change field lookup.
+  class ContextReader
+    REQUEST_ID = "request_id"
+    REQUEST_DEPTH = "request_depth"
+    TREE_PATH = "tree_path"
+
+    def initialize(subject)
+      @subject = subject
+    end
+
+    def [](key)
+      subject[key]
+    end
+
+    def request_id
+      self[REQUEST_ID] || SecureRandom.uuid
+    end
+
+    def tree_root?
+      !self[REQUEST_ID]
+    end
+
+    def request_depth
+      tree_root? ? 0 : (self[REQUEST_DEPTH].to_i + 1)
+    end
+
+    def tree_path
+      if tree_root?
+        SubrequestHelper.root_path(synchronous: false)
+      else
+        self[TREE_PATH]
+      end
+    end
+
+    private
+
+    attr_reader :subject
+  end
+end

--- a/lib/kiev/request_id.rb
+++ b/lib/kiev/request_id.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Kiev
+  module RequestId
+    module Mixin
+      NEW_LINE = "\n"
+
+      def wrap_request_id(context_reader, &_block)
+        request_store = Kiev::RequestStore.store
+        request_store[:request_id] = context_reader.request_id
+        request_store[:request_depth] = context_reader.request_depth
+        request_store[:tree_path] = context_reader.tree_path
+        yield
+      end
+    end
+  end
+end

--- a/lib/kiev/request_logger.rb
+++ b/lib/kiev/request_logger.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Kiev
+  module RequestLogger
+    module Mixin
+      NEW_LINE = "\n"
+
+      def wrap_request_logger(event, **data, &_block)
+        began_at = Time.now
+        error = nil
+
+        begin
+          return_value = yield
+        rescue StandardError => exception
+          error = exception
+        end
+
+        begin
+          data[:request_duration] = ((Time.now - began_at) * 1000).round(3)
+          if error
+            data[:error_class] = error.class.name
+            data[:error_message] = error.message[0..5000]
+            data[:error_backtrace] = Array(error.backtrace).join(NEW_LINE)[0..5000]
+          end
+
+          Kiev.event(event, data)
+        ensure
+          raise error if error
+          return_value
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken.rb
+++ b/lib/kiev/shoryuken.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Kiev
+  module Shoryuken
+    require_relative "shoryuken/middleware"
+
+    class << self
+      def enable(base = nil)
+        base ||= ::Shoryuken
+        base.configure_client do |config|
+          enable_client_middleware(config)
+        end
+        base.configure_server do |config|
+          enable_client_middleware(config)
+          enable_server_middleware(config)
+        end
+      end
+
+      def enable_server_middleware(config)
+        server_mw_enabled = false
+        config.server_middleware do |chain|
+          chain.add(Middleware::RequestStore)
+          chain.add(Middleware::RequestId)
+          chain.add(Middleware::StoreRequestDetails)
+          chain.add(Middleware::RequestLogger)
+          server_mw_enabled = true
+        end
+        server_mw_enabled # Shoryuken configuration may skip that block in non-worker setups
+      end
+
+      def enable_client_middleware(config)
+        config.client_middleware do |chain|
+          chain.add(Middleware::MessageTracer)
+        end
+      end
+
+      def suffix_tree_path(config, tag)
+        config.server_middleware do |chain|
+          chain.insert_after(Middleware::RequestId, Middleware::TreePathSuffix, tag)
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/context_reader.rb
+++ b/lib/kiev/shoryuken/context_reader.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "kiev/context_reader"
+
+module Kiev
+  module Shoryuken
+    class ContextReader < Kiev::ContextReader
+      def initialize(message)
+        super
+        @message_attributes = message.message_attributes
+      end
+
+      def [](key)
+        return unless @message_attributes.key?(key)
+        attribute_value = @message_attributes[key]
+        return unless attribute_value.data_type == "String"
+        attribute_value.string_value
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware.rb
+++ b/lib/kiev/shoryuken/middleware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Client middleware
+require_relative "middleware/message_tracer"
+
+# Server middleware
+require_relative "middleware/request_id"
+require_relative "middleware/request_logger"
+require_relative "middleware/request_store"
+require_relative "middleware/store_request_details"
+require_relative "middleware/tree_path_suffix"

--- a/lib/kiev/shoryuken/middleware/message_tracer.rb
+++ b/lib/kiev/shoryuken/middleware/message_tracer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Kiev
+  module Shoryuken
+    module Middleware
+      class MessageTracer
+        def call(options)
+          attrbutes = options[:message_attributes] ||= {}
+          SubrequestHelper.payload.each do |key, value|
+            attrbutes[key] = {
+              data_type: "String",
+              string_value: value.to_s
+            }
+          end
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware/request_id.rb
+++ b/lib/kiev/shoryuken/middleware/request_id.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "kiev/request_id"
+require "kiev/shoryuken/context_reader"
+
+module Kiev
+  module Shoryuken
+    module Middleware
+      class RequestId
+        include Kiev::RequestId::Mixin
+
+        def call(_worker, _queue, message, _body, &block)
+          context_reader = Kiev::Shoryuken::ContextReader.new(message)
+          wrap_request_id(context_reader, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware/request_logger.rb
+++ b/lib/kiev/shoryuken/middleware/request_logger.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Kiev
+  module Shoryuken
+    module Middleware
+      class RequestLogger
+        include Kiev::RequestLogger::Mixin
+
+        def call(_worker, _queue, _message, body, &block)
+          wrap_request_logger(:job_finished, body: body, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware/request_store.rb
+++ b/lib/kiev/shoryuken/middleware/request_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Kiev
+  module Shoryuken
+    module Middleware
+      class RequestStore
+        include Kiev::RequestStore::Mixin
+
+        def call(_worker, _queue, _message, _body, &block)
+          wrap_request_store(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware/store_request_details.rb
+++ b/lib/kiev/shoryuken/middleware/store_request_details.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "kiev/shoryuken/context_reader"
+
+module Kiev
+  module Shoryuken
+    module Middleware
+      class StoreRequestDetails
+        def call(_worker, _queue, message, _body)
+          context_reader = Kiev::Shoryuken::ContextReader.new(message)
+          Config.instance.jobs_propagated_fields.each do |key|
+            Kiev[key] = context_reader[key]
+          end
+          request_store = Kiev::RequestStore.store
+          request_store[:background_job] = true
+          request_store[:message_id] = message.message_id
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware/tree_path_suffix.rb
+++ b/lib/kiev/shoryuken/middleware/tree_path_suffix.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Kiev
+  module Shoryuken
+    module Middleware
+      class TreePathSuffix
+        def initialize(tag)
+          @tag = tag.dup.freeze
+        end
+
+        def call(_worker, _queue, _message, _body)
+          request_store = Kiev::RequestStore.store
+          request_store[:tree_path] ||= ""
+          request_store[:tree_path] += @tag
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/sidekiq/request_id.rb
+++ b/lib/kiev/sidekiq/request_id.rb
@@ -1,38 +1,17 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "kiev/request_id"
+require "kiev/context_reader"
 
 module Kiev
   module Sidekiq
     class RequestId
-      REQUEST_ID = "request_id"
-      REQUEST_DEPTH = "request_depth"
-      TREE_PATH = "tree_path"
+      include Kiev::RequestId::Mixin
 
-      def call(_worker, job, _queue)
-        Kiev::RequestStore.store[:request_id] = request_id(job)
-        Kiev::RequestStore.store[:request_depth] = request_depth(job)
-        Kiev::RequestStore.store[:tree_path] = tree_path(job)
-        yield
-      end
-
-      private
-
-      def request_id(job)
-        # cron jobs will be triggered without request_id
-        job[REQUEST_ID] || SecureRandom.uuid
-      end
-
-      def tree_root?(job)
-        !job[REQUEST_ID]
-      end
-
-      def request_depth(job)
-        tree_root?(job) ? 0 : (job[REQUEST_DEPTH].to_i + 1)
-      end
-
-      def tree_path(job)
-        tree_root?(job) ? SubrequestHelper.root_path(synchronous: false) : job[TREE_PATH]
+      def call(_worker, job, _queue, &block)
+        context_reader = Kiev::ContextReader.new(job)
+        wrap_request_id(context_reader, &block)
       end
     end
   end

--- a/lib/kiev/sidekiq/request_logger.rb
+++ b/lib/kiev/sidekiq/request_logger.rb
@@ -3,36 +3,12 @@
 module Kiev
   module Sidekiq
     class RequestLogger
-      NEW_LINE = "\n"
+      include Kiev::RequestLogger::Mixin
+
       ARGS = "args"
 
-      def call(_worker, job, _queue)
-        began_at = Time.now
-        error = nil
-
-        begin
-          return_value = yield
-        rescue Exception => exception
-          error = exception
-        end
-
-        begin
-          data = {
-            params: job[ARGS],
-            request_duration: ((Time.now - began_at) * 1000).round(3)
-          }
-
-          if error
-            data[:error_class] = error.class.name
-            data[:error_message] = error.message[0..5000]
-            data[:error_backtrace] = Array(error.backtrace).join(NEW_LINE)[0..5000]
-          end
-
-          Kiev.event(:job_finished, data)
-        ensure
-          raise error if error
-          return_value
-        end
+      def call(_worker, job, _queue, &block)
+        wrap_request_logger(:job_finished, params: job[ARGS], &block)
       end
     end
   end

--- a/lib/kiev/test.rb
+++ b/lib/kiev/test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Kiev
+  # Test helpers for testing both Kiev itself and products that use it.
+  module Test
+    module Log
+      STREAM = StringIO.new
+
+      module_function
+
+      def configure
+        @logs = []
+        Kiev.configure do |c|
+          c.log_path = STREAM
+        end
+      end
+
+      def clear
+        STREAM.rewind
+        STREAM.truncate(0)
+        @logs = []
+      end
+
+      def entries
+        return @logs unless @logs.empty?
+        @logs = raw_logs.each_line.map(&::JSON.method(:parse))
+      rescue
+        puts raw_logs
+        raise
+      end
+
+      def raw_logs
+        STREAM.string
+      end
+    end
+  end
+end

--- a/spec/lib/kiev/shoryuken_spec.rb
+++ b/spec/lib/kiev/shoryuken_spec.rb
@@ -1,0 +1,358 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "kiev/test"
+
+if defined?(::Shoryuken)
+  RSpec.describe Kiev::Shoryuken do
+    # {
+    #   message_id: "437eb14c-7a98-457c-a431-01671564237e",
+    #   body: "test",
+    #   message_attributes: message_attributes,
+    #   delete: nil
+    # }
+    # {
+    #   "request_id"    => "acc6acfe-525e-49a6-a12b-ce3f07564620",
+    #   "request_depth" => 1,
+    #   "tree_path"     => "B"
+    # }
+
+    before(:all) do
+      # Shoryuken skips configure_server blocks unless it's running in a worker
+      # process. "worker process"ness is defined only by existence of this module.
+      # In Shoryuken itself it's only defined in `bin` and only gets created when
+      # using `shoryuken` executable. It's not (readily) available for requiring.
+      module Shoryuken::CLI
+      end
+
+      Shoryuken.logger.level = Logger::FATAL
+      Kiev::Shoryuken.enable
+      Kiev::Test::Log.configure
+    end
+
+    describe "client middleware when sending a message" do
+      include Kiev::RequestStore::Mixin
+
+      let(:credentials) { Aws::Credentials.new("access_key_id", "secret_access_key") }
+      let(:sqs) { Aws::SQS::Client.new(stub_responses: true, credentials: credentials) }
+      let(:queue_name) { "default" }
+      let(:queue_url) { "https://sqs.eu-west-1.amazonaws.com:6059/0123456789/#{queue_name}" }
+
+      let(:queue) { Shoryuken::Queue.new(sqs, queue_name) }
+      before do
+        allow(queue).to receive(:url).and_return(queue_url)
+        allow(sqs).to receive(:send_message)
+      end
+
+      around(:each) do |example|
+        wrap_request_store { example.run }
+      end
+
+      let(:message_attributes) { {} }
+      let(:formatted_attributes) do
+        next unless message_attributes
+        message_attributes.each_with_object({}) do |(k, v), attrs|
+          attrs[k.to_s] = { data_type: "String", string_value: v }
+        end
+      end
+
+      def send_message
+        message = { message_body: '{"a": 42}' }
+        if message_attributes
+          message[:message_attributes] = formatted_attributes
+        end
+        queue.send_message(message)
+      end
+
+      context "without anything in Kiev store" do
+        before { send_message }
+
+        it "tags it with tree_path B (first request, asynchronous)" do
+          expect(sqs)
+            .to have_received(:send_message)
+            .with(hash_including(message_attributes: { "tree_path" => { data_type: "String", string_value: "B" } }))
+        end
+      end
+
+      context "with a specified request_id in Kiev store" do
+        let(:request_id) { "acc6acfe-525e-49a6-a12b-ce3f07564620" }
+
+        before do
+          Kiev::RequestStore.store[:request_id] = request_id
+        end
+
+        it "preserves request_id" do
+          expect(sqs)
+            .to receive(:send_message)
+            .with(
+              hash_including(
+                message_attributes: hash_including(
+                  "request_id" => { data_type: "String", string_value: request_id }
+                )
+              )
+            )
+          send_message
+        end
+      end
+
+      context "with a specified tree_path in Kiev store" do
+        let(:source_tree_path) { "DAaaAAaAAAAAaaAAaaA" }
+
+        before do
+          Kiev::RequestStore.store[:tree_path] = source_tree_path
+        end
+
+        it "appends B to tree_path" do
+          expect(sqs)
+            .to receive(:send_message)
+            .with(
+              hash_including(
+                message_attributes: hash_including(
+                  "tree_path" => { data_type: "String", string_value: (source_tree_path + "B") }
+                )
+              )
+            )
+          send_message
+        end
+      end
+
+      context "with a specified request depth in Kiev store" do
+        let(:request_depth) { 5 }
+
+        before do
+          Kiev::RequestStore.store[:request_depth] = request_depth
+        end
+
+        it "preserves it as a string" do
+          expect(sqs)
+            .to receive(:send_message)
+            .with(
+              hash_including(
+                message_attributes: hash_including(
+                  "request_depth" => { data_type: "String", string_value: request_depth.to_s }
+                )
+              )
+            )
+          send_message
+        end
+      end
+    end
+
+    describe "server middleware" do
+      context "when receiving a message" do
+        let(:queue)     { "default" }
+        let(:sqs_queue) { double(Shoryuken::Queue, visibility_timeout: 30) }
+
+        let(:processor) { Shoryuken::Processor.new(queue, sqs_msg) }
+
+        let(:message_body) { "test" }
+        let(:message_attributes) { {} }
+
+        let(:formatted_attributes) do
+          message_attributes.each_with_object({}) do |(k, v), attrs|
+            attrs[k.to_s] = double(
+              Aws::SQS::Types::MessageAttributeValue,
+              data_type: "String",
+              string_value: v
+            )
+          end
+        end
+
+        def sqs_msg_from(**attrs)
+          double(
+            Shoryuken::Message,
+            message_id: SecureRandom.uuid,
+            receipt_handle: SecureRandom.uuid,
+            **attrs
+          )
+        end
+
+        let(:sqs_msg_attrs) do
+          {
+            queue_url: queue,
+            body: message_body,
+            message_attributes: formatted_attributes
+          }
+        end
+
+        let(:sqs_msg) { sqs_msg_from(sqs_msg_attrs) }
+
+        before do
+          class TestWorker
+            include Shoryuken::Worker
+            shoryuken_options queue: "default"
+
+            def perform(_sqs_msg, _body)
+              true
+            end
+          end
+
+          allow(Shoryuken::Client).to receive(:queues).with(queue).and_return(sqs_queue)
+        end
+
+        before  { Kiev::Test::Log.clear }
+
+        context "without message attributes" do
+          it { expect { processor.process }.to_not raise_error }
+
+          describe "logged entry" do
+            subject { Kiev::Test::Log.entries.first }
+
+            before { processor.process }
+
+            it { is_expected.to be_a(Hash) }
+
+            it "has fields of a successful job" do
+              is_expected.to include(
+                "event" => "job_finished",
+                "level" => "INFO",
+                "body" => message_body,
+                "tree_leaf" => true,
+                "tree_path" => "B",
+                "request_depth" => 0,
+                "timestamp" => a_string_matching(/.+/),
+                "request_id" => a_string_matching(/.+/),
+                "request_duration" => (a_value > 0)
+              )
+            end
+
+            it "has no error fields" do
+              is_expected.to_not include(
+                "error_class",
+                "error_message",
+                "error_backtrace"
+              )
+            end
+
+            it "does not populate the store with a new request_id" do
+              expect(Kiev::RequestStore.store).to_not have_key(:request_id)
+            end
+
+            context "when two messages are sent" do
+              let(:other_sqs_msg) { sqs_msg_from(sqs_msg_attrs) }
+              let(:other_processor) { Shoryuken::Processor.new(queue, other_sqs_msg) }
+              before { other_processor.process }
+
+              it "generates different request_ids" do
+                first, second = Kiev::Test::Log.entries
+                expect(first["request_id"]).to_not eq(second["request_id"])
+              end
+            end
+          end
+        end
+
+        context "with message attributes" do
+          let(:request_id) { "acc6acfe-525e-49a6-a12b-ce3f07564620" }
+          let(:tree_path) { "AWYeAH" }
+          let(:request_depth) { tree_path.length }
+
+          let(:message_attributes) do
+            {
+              request_id: request_id,
+              tree_path: tree_path,
+              request_depth: request_depth
+            }
+          end
+
+          describe "logged_entry" do
+            before { processor.process }
+            subject { Kiev::Test::Log.entries.first }
+            it "processes tracing fields properly" do
+              is_expected.to include(
+                "request_id" => request_id,
+                "tree_path" => tree_path,
+                "request_depth" => (request_depth + 1)
+              )
+            end
+          end
+        end
+
+        describe "failing worker" do
+          let(:queue) { "error" }
+
+          before do
+            class UnexpectedFailure < StandardError; end
+
+            class FailingWorker
+              include Shoryuken::Worker
+              shoryuken_options queue: "error"
+
+              def perform(_sqs_msg, _body)
+                raise UnexpectedFailure, "error message"
+              end
+            end
+
+            allow(Shoryuken::Client)
+              .to receive(:queues)
+              .with(queue)
+              .and_return(sqs_queue)
+          end
+
+          it "doesn't rescue the exception" do
+            expect { processor.process }.to raise_error(UnexpectedFailure)
+          end
+
+          describe "logged entry" do
+            subject { Kiev::Test::Log.entries.first }
+
+            before do
+              begin
+                processor.process
+              rescue UnexpectedFailure
+              end
+            end
+
+            it "describes the error" do
+              is_expected.to include(
+                "error_class" => UnexpectedFailure.to_s,
+                "error_message" => "error message",
+                "error_backtrace" => an_instance_of(String)
+              )
+            end
+          end
+        end
+
+        context "when tree_path suffixing is configured explicitly" do
+          let(:queue) { "suffixed" }
+          let(:tree_path) { "ABD" }
+          let(:suffix) { "K" }
+          let(:message_attributes) do
+            {
+              request_id: SecureRandom.uuid,
+              request_depth: tree_path.length,
+              tree_path: tree_path
+            }
+          end
+
+          before do
+            Shoryuken.configure_server do |config|
+              Kiev::Shoryuken.suffix_tree_path(config, suffix)
+            end
+            class SuffixedWorker
+              include Shoryuken::Worker
+              shoryuken_options queue: "suffixed"
+
+              def perform(_sqs_msg, _body)
+                true
+              end
+            end
+            processor.process
+          end
+
+          after do
+            Shoryuken.configure_server do |config|
+              config.server_middleware.remove(Kiev::Shoryuken::Middleware::TreePathSuffix)
+            end
+          end
+
+          describe "logged entry" do
+            subject { Kiev::Test::Log.entries.first }
+            it "adds a configured suffix to it" do
+              is_expected.to include("tree_path" => tree_path + suffix)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes Kiev fully capable of leaving a trace from Amazon SQS messages processed by [Shoryuken](https://github.com/phstc/shoryuken).

Interface mostly mirrors that for Sidekiq, but with a few twists here and there:

* SQS `message_attributes` are used for transporting tracing context: make sure the corresponding attributes are available in messages (e. g. susbcriptions to SNS require "Raw Message Delivery")
* Additional utility middleware added, though not included by default, that adds suffixes to `tree_path` for situations where one tracing context is consumed in multiple different places that you need to identify separately in the trace. See changes to README for a practical example.