### PR TITLE
Add soap content type to xml filter. Get documentation up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,20 @@ Kiev.configure do |config|
 end
 ```
 
+### log_request_body_condition
+
+By default, Kiev doesn't log the request body of XML requests because they tend to be more verbose.
+
+You can override this behaviour via the `log_request_body_condition` option, which should be a `proc` returning a `boolean`:
+
+```ruby
+Kiev.configure do |config|
+  config.log_request_body_condition = proc do |request, _response|
+    !!(request.content_type =~ /(application|text)\/xml/)
+  end
+end
+```
+
 ### log_request_error_condition
 
 Kiev logs Ruby exceptions. By default, it won't log the exceptions produced by 404s.

--- a/lib/kiev/request_body_filter.rb
+++ b/lib/kiev/request_body_filter.rb
@@ -10,7 +10,7 @@ module Kiev
     FILTERED = "[FILTERED]"
 
     JSON_CONTENT_TYPE = %w(text/json application/json)
-    XML_CONTENT_TYPES = %w(text/xml application/xml)
+    XML_CONTENT_TYPES = %w(text/xml application/xml application/soap+xml)
     FORM_DATA_CONTENT_TYPES = %w(application/x-www-form-urlencoded multipart/form-data)
 
     def self.for_content_type(content_type)


### PR DESCRIPTION
- Adding the [soap content type](https://tools.ietf.org/html/rfc3902) to the XML parameter filter
- Adding some missing documentation