### PR TITLE
[CHARLIE-NO-TICKET] support for kafka/AWS SNS messages context tracking

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         ruby: ['2.5.1', '2.7.2', '2.6.5']
         gemfile:
+          - gemfiles/ruby_kafka.gemfile
           - gemfiles/que_0.12.2.gemfile
           - gemfiles/que_0.12.3.gemfile
           - gemfiles/rails_5.2.gemfile

--- a/README.md
+++ b/README.md
@@ -154,6 +154,36 @@ Kiev::Shoryuken.enable
 
 The name of the worker class is not logged by default. Configure [`persistent_log_fields` option](#persistent_log_fields) to include `"shoryuken_class"` if you want this.
 
+### AWS SNS
+
+To enhance messages published to SNS topics you can use the ContextInjector:
+
+```ruby
+sns_message = { topic_arn: "...",  message: "{...}" }
+Kiev::Kafka.inject_context(sns_message[:message_attributes])
+
+```
+
+After this operation the message attributes will also include required context for the Kiev logger.
+
+### Kafka
+
+To enhance messages published to Kafka topics you can use the ContextInjector:
+
+```ruby
+Kiev::Kafka.inject_context(headers)
+```
+
+After this operation the headers variable will also include required context for the Kiev logger.
+
+If you have a consumed `Kafka::FetchedMessage` you can extract logger context with: 
+
+```ruby
+Kiev::Kafka.extract_context(message)
+```
+
+This will work regardless if headers are in HTTP format, e.g. `X-Tracking-Id` or plain field names: `tracking_id`. Plus the `message_key` field will contain the key of processed message. In case you want to log some more fields configure `persistent_log_fields` and `jobs_propagated_fields`.  
+
 ### Que
 
 Add the following lines to your initializer code:
@@ -219,7 +249,9 @@ For web requests the Kiev middleware will log the following information by defau
 
 * `params` attribute will store both query parameters and request body fields (as long as they are parseable). Sensitive fields will be filtered out - see the `#filtered_params` option.
 
-* `request_id` is the correlation ID and will be the same across all requests within a chain of requests. It's represented as a UUID (version 4).
+* `request_id` is the correlation ID and will be the same across all requests within a chain of requests. It's represented as a UUID (version 4). (currently deprecated in favor of a new name: `tracking_id`)
+
+* `tracking_id` is the correlation ID and will be the same across all requests within a chain of requests. It's represented as a UUID (version 4). If not provided the value is seeded from deprecated `request_id`. 
 
 * `request_depth` represents the position of the current request within a chain of requests. It starts with 0.
 

--- a/gemfiles/ruby_kafka.gemfile
+++ b/gemfiles/ruby_kafka.gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "ruby-kafka", "~> 0.7.10"
+
+gem "rack-test", require: false
+gem "rspec", require: false
+gem "minitest-reporters", require: false
+
+gemspec path: "../"

--- a/kiev.gemspec
+++ b/kiev.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1", "< 3"
   spec.add_dependency "request_store", ">= 1.0", "< 1.4"
   spec.add_dependency "ruby_dig", "~> 0.0.2" # to support ruby 2.2
-  spec.add_development_dependency "rake", '~> 0'
-  spec.add_development_dependency "rspec", '~> 0'
+  spec.add_development_dependency "rake", "~> 0"
+  spec.add_development_dependency "rspec", "~> 0"
   spec.add_development_dependency "rubocop", "~> 0.54"
 end

--- a/kiev.gemspec
+++ b/kiev.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1", "< 3"
   spec.add_dependency "request_store", ">= 1.0", "< 1.4"
   spec.add_dependency "ruby_dig", "~> 0.0.2" # to support ruby 2.2
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rake", '~> 0'
+  spec.add_development_dependency "rspec", '~> 0'
   spec.add_development_dependency "rubocop", "~> 0.54"
 end

--- a/kiev.gemspec
+++ b/kiev.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "request_store", ">= 1.0", "< 1.4"
   spec.add_dependency "ruby_dig", "~> 0.0.2" # to support ruby 2.2
   spec.add_development_dependency "rake", "~> 0"
-  spec.add_development_dependency "rspec", "~> 0"
+  spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rubocop", "~> 0.54"
 end

--- a/lib/kiev.rb
+++ b/lib/kiev.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "kiev/base"
+require_relative "kiev/aws_sns" if defined?(AWS::SNS)
 require_relative "kiev/kafka" if defined?(Kafka)
 require_relative "kiev/rack" if defined?(Rack)
 require_relative "kiev/railtie" if defined?(Rails)

--- a/lib/kiev.rb
+++ b/lib/kiev.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "kiev/base"
+require_relative "kiev/kafka" if defined?(Kafka)
 require_relative "kiev/rack" if defined?(Rack)
 require_relative "kiev/railtie" if defined?(Rails)
 require_relative "kiev/sidekiq" if defined?(Sidekiq)

--- a/lib/kiev/aws_sns.rb
+++ b/lib/kiev/aws_sns.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Kiev
+  module AwsSns
+    require_relative "kafka/context_injector"
+
+    class << self
+      # @param [Hash] headers
+      def inject_context(headers = {})
+        Kiev::AwsSns::ContextInjector.new.call(headers)
+      end
+    end
+  end
+end

--- a/lib/kiev/aws_sns/context_injector.rb
+++ b/lib/kiev/aws_sns/context_injector.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "kiev/config"
+require "kiev/subrequest_helper"
+
+module Kiev
+  module AwsSns
+    class ContextInjector
+      # @param [Hash] message_attributes Injects context headers
+      # @return [Hash]
+      def call(message_attributes = {})
+        Kiev::SubrequestHelper.payload.each do |key, value|
+          message_attributes[key] = {
+            data_type: "String",
+            string_value: value.to_s
+          }
+        end
+        message_attributes
+      end
+    end
+  end
+end

--- a/lib/kiev/base.rb
+++ b/lib/kiev/base.rb
@@ -47,7 +47,9 @@ module Kiev
     end
 
     def request_id
-      RequestStore.store[:request_id]
+      RequestStore.store[:tracking_id]
     end
+
+    alias_method :tracking_id, :request_id
   end
 end

--- a/lib/kiev/kafka.rb
+++ b/lib/kiev/kafka.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Kiev
+  module Kafka
+    require_relative "kafka/context_extractor"
+    require_relative "kafka/context_injector"
+
+    class << self
+      # @param [Kafka::FetchedMessage] message
+      def extract_context(message)
+        Kiev::Kafka::ContextExtractor.new.call(message)
+      end
+
+      # @param [Hash] headers
+      def inject_context(headers = {})
+        Kiev::Kafka::ContextInjector.new.call(headers)
+      end
+    end
+  end
+end

--- a/lib/kiev/kafka/context_extractor.rb
+++ b/lib/kiev/kafka/context_extractor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 require_relative "message_context"
 require "kiev/request_id"
 require "kiev/context_reader"

--- a/lib/kiev/kafka/context_extractor.rb
+++ b/lib/kiev/kafka/context_extractor.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+
+require_relative "message_context"
+require "kiev/request_id"
+require "kiev/context_reader"
+
+module Kiev
+  module Kafka
+    class ContextExtractor
+      include Kiev::RequestId::Mixin
+
+      # @param [Kafka::FetchedMessage] message
+      def call(message)
+        context = Kiev::Kafka::MessageContext.new(message)
+        context_reader = Kiev::ContextReader.new(context)
+        wrap_request_id(context_reader) {}
+
+        Kiev[:message_key] = message.key
+
+        Config.instance.jobs_propagated_fields.each do |key|
+          Kiev[key] = context_reader[key]
+        end
+      end
+    end
+  end
+end

--- a/lib/kiev/kafka/context_injector.rb
+++ b/lib/kiev/kafka/context_injector.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 require_relative "message_context"
 require "kiev/request_id"
 require "kiev/context_reader"

--- a/lib/kiev/kafka/context_injector.rb
+++ b/lib/kiev/kafka/context_injector.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "message_context"
-require "kiev/request_id"
-require "kiev/context_reader"
+require "kiev/config"
+require "kiev/subrequest_helper"
 
 module Kiev
   module Kafka
     class ContextInjector
-      include Kiev::RequestId::Mixin
-
       # @param [Hash] headers Injects context headers
       # @return [Hash]
       def call(headers = {})

--- a/lib/kiev/kafka/context_injector.rb
+++ b/lib/kiev/kafka/context_injector.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+
+require_relative "message_context"
+require "kiev/request_id"
+require "kiev/context_reader"
+
+module Kiev
+  module Kafka
+    class ContextInjector
+      include Kiev::RequestId::Mixin
+
+      # @param [Hash] headers Injects context headers
+      # @return [Hash]
+      def call(headers = {})
+        Kiev::SubrequestHelper.payload.each do |key, value|
+          field_key = Kiev::Config::DEFAULT_HTTP_PROPAGATED_FIELDS.fetch(key.to_sym, key)
+          headers[field_key] = value
+        end
+        headers
+      end
+    end
+  end
+end

--- a/lib/kiev/kafka/message_context.rb
+++ b/lib/kiev/kafka/message_context.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Kiev
+  module Kafka
+    class MessageContext
+      # @param [Kafka::FetchedMessage] message
+      def initialize(message)
+        @headers = message.headers
+      end
+
+      def value(field)
+        headers[header_key(field)] || headers[field.to_s]
+      end
+
+      alias_method :[], :value
+
+      private
+
+      attr_reader :headers
+
+      # @param [String] field
+      def header_key(field)
+        "x_#{field}".gsub("_", " ").split.map(&:capitalize).join("-")
+      end
+    end
+  end
+end

--- a/lib/kiev/shoryuken/middleware/message_tracer.rb
+++ b/lib/kiev/shoryuken/middleware/message_tracer.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
+require "kiev/aws_sns/context_injector"
+
 module Kiev
   module Shoryuken
     module Middleware
       class MessageTracer
         def call(options)
-          attrbutes = options[:message_attributes] ||= {}
-          SubrequestHelper.payload.each do |key, value|
-            attrbutes[key] = {
-              data_type: "String",
-              string_value: value.to_s
-            }
-          end
+          options[:message_attributes] ||= {}
+          Kiev::AwsSns::ContextInjector.new.call(options[:message_attributes])
           yield
         end
       end

--- a/spec/lib/kiev/kafka/context_extractor_spec.rb
+++ b/spec/lib/kiev/kafka/context_extractor_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby-kafka"
+
+if defined?(::Kafka)
+  describe Kiev::Kafka::ContextExtractor do
+    after do
+      ::RequestStore.store[:kiev] = {}
+      ::RequestStore.store.delete(:subrequest_count)
+    end
+    context 'when message has context' do
+      let(:tracking_id) { SecureRandom.uuid }
+
+      subject { described_class.new.call(message) }
+      let(:headers) do
+        {
+          "X-Tracking-Id" => tracking_id,
+          "X-Tree-Path" =>"KAFKA",
+          "X-Request-Depth" => "4"
+        }
+      end
+      let(:message) do
+        Kafka::FetchedMessage.new(message: Kafka::Protocol::Record.new(key: "msg_key", value: "", headers: headers), topic: "", partition: 0)
+      end
+      it "extracts basic fields" do
+        subject
+        expect(Kiev.request_id).to eq(tracking_id)
+        expect(Kiev::RequestStore.store[:tree_path]).to eq("KAFKA")
+        expect(Kiev::RequestStore.store[:request_depth]).to eq(5)
+        expect(Kiev::RequestStore.store.dig(:payload, :message_key)).to eq("msg_key")
+      end
+
+      context "for headers in plain format (no X- and uppercase)" do
+        let(:headers) do
+          {
+            "tracking_id" => tracking_id,
+            "tree_path" =>"KAFkA",
+            "request_depth" => "3"
+          }
+        end
+
+        it "extracts them as well" do
+          subject
+          expect(Kiev.request_id).to eq(tracking_id)
+          expect(Kiev::RequestStore.store[:tree_path]).to eq("KAFkA")
+          expect(Kiev::RequestStore.store[:request_depth]).to eq(4)
+          expect(Kiev::RequestStore.store.dig(:payload, :message_key)).to eq("msg_key")
+        end
+      end
+
+      context "extra fields if job-propagated are also stored in payload context" do
+        let(:headers) do
+          {
+            "other_uuid" => tracking_id,
+            "skip_me" =>"not tracked",
+            "X-Accept-This" => "3"
+          }
+        end
+
+        it "extracts them as well" do
+          allow(Kiev::Config.instance).to receive(:jobs_propagated_fields).and_return(%i(other_uuid accept_this))
+          subject
+          payload_context = Kiev::RequestStore.store[:payload]
+          expect(payload_context[:other_uuid]).to eq(tracking_id)
+          expect(payload_context[:accept_this]).to eq("3")
+          expect(payload_context[:skip_me]).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/kiev/kafka/context_extractor_spec.rb
+++ b/spec/lib/kiev/kafka/context_extractor_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "ruby-kafka"
 
 if defined?(::Kafka)
   describe Kiev::Kafka::ContextExtractor do

--- a/spec/lib/kiev/kafka/context_injector_spec.rb
+++ b/spec/lib/kiev/kafka/context_injector_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "ruby-kafka"
 
 if defined?(::Kafka)
   describe Kiev::Kafka::ContextInjector do

--- a/spec/lib/kiev/kafka/context_injector_spec.rb
+++ b/spec/lib/kiev/kafka/context_injector_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby-kafka"
+
+if defined?(::Kafka)
+  describe Kiev::Kafka::ContextInjector do
+    before do
+      ::RequestStore.store[:subrequest_count] = 3
+    end
+    after do
+      ::RequestStore.store[:kiev] = {}
+      ::RequestStore.store.delete(:subrequest_count)
+    end
+
+    let(:kiev_store) { Kiev::RequestStore.store }
+
+    subject { described_class.new.call }
+    let(:tracking_id) { SecureRandom.uuid }
+    before do
+      kiev_store[:tracking_id] = tracking_id
+    end
+
+    it "injects payload context into hash argument" do
+      expect(subject).to eq(
+        "X-Tracking-Id" => tracking_id,
+        "X-Tree-Path" => "B"
+      )
+    end
+
+    context "when more context present" do
+      before do
+        kiev_store[:tree_path] = "FAKA"
+        kiev_store[:request_id] = tracking_id
+        kiev_store[:request_depth] = 3
+      end
+
+      it "returns more in headers" do
+        expect(subject).to eq(
+          "X-Tracking-Id" => tracking_id,
+          "X-Request-Id" => tracking_id,
+          "X-Request-Depth" => 3,
+          "X-Tree-Path" => "FAKAB"
+        )
+      end
+    end
+
+    context "when jobs_propagated_fields setup" do
+      before do
+        default_setup = Kiev::Config.instance.all_jobs_propagated_fields
+        allow(Kiev::Config.instance).to receive(:all_jobs_propagated_fields).and_return(
+          default_setup + %i(some_other_field and_another)
+        )
+        Kiev[:some_other_field] = "foo"
+        Kiev[:and_another] = "bar"
+        Kiev[:skip_me] = "bar"
+      end
+
+      it "passes them" do
+        expect(subject).to eq(
+          "X-Tracking-Id" => tracking_id,
+          "X-Tree-Path" => "B",
+          "some_other_field" => "foo",
+          "and_another" => "bar"
+        )
+      end
+    end
+
+    it "enhances argument headers variable as well" do
+      some_headers = {foo: 42}
+      described_class.new.call(some_headers)
+      expect(some_headers).to eq(
+        "X-Tracking-Id" => tracking_id,
+        "X-Tree-Path" => "B",
+        foo: 42
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "delegate"
+
 Bundler.require :default, :development
 require "rack/test" if defined?(Rack)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "delegate"
 
 Bundler.require :default, :development
 


### PR DESCRIPTION
More and more systems are using Kafka for messaging. Kiev library have support for Shoryuken/AWS SNS messages. 

This PR adds support for headers transporting log context also for Ruby Kafka messages. The context is extracted from headers if the keys are in HTTP-like format: `X-Tracking-Id` or plain form: `tracking_id`. 

It also adds separate context injector for AWS SNS messages in case it's needed outside of Shoryuken.