### PR TITLE
Support Kiev.event data as string

### DIFF
--- a/lib/kiev/base.rb
+++ b/lib/kiev/base.rb
@@ -35,15 +35,9 @@ module Kiev
     end
 
     def event(event_name, data = EMPTY_OBJ)
-      filtered_data = if ParamFilter.filterable?(data)
-        ParamFilter.filter(data, filtered_params, ignored_params)
-      else
-        data
-      end
-
       logger.log(
         ::Logger::Severity::INFO,
-        filtered_data,
+        ParamFilter.filter(data, filtered_params, ignored_params),
         event_name
       )
     end

--- a/lib/kiev/param_filter.rb
+++ b/lib/kiev/param_filter.rb
@@ -4,10 +4,6 @@ module Kiev
   class ParamFilter
     FILTERED = "[FILTERED]"
 
-    def self.filterable?(params)
-      params.respond_to?(:each_with_object)
-    end
-
     def self.filter(params, filtered_params, ignored_params)
       new(filtered_params, ignored_params).call(params)
     end
@@ -18,6 +14,8 @@ module Kiev
     end
 
     def call(params)
+      return params unless filterable?(params)
+
       params.each_with_object({}) do |(key, value), acc|
         next if ignored_params.include?(key.to_s)
 
@@ -43,6 +41,10 @@ module Kiev
     private
 
     attr_reader :filtered_params, :ignored_params
+
+    def filterable?(params)
+      params.respond_to?(:each_with_object)
+    end
 
     def normalize(params)
       Set.new(params.map(&:to_s))

--- a/spec/lib/kiev/param_filter_spec.rb
+++ b/spec/lib/kiev/param_filter_spec.rb
@@ -3,22 +3,6 @@
 require "spec_helper"
 
 describe Kiev::ParamFilter do
-  describe "filterable" do
-    subject(:filterable?) { described_class.filterable?(params) }
-
-    context "when params is a string" do
-      let(:params) { "non filterable string, yet" }
-
-      it { is_expected.to eq(false) }
-    end
-
-    context "when params are a Hash" do
-      let(:params) { { "filterable" => "params" } }
-
-      it { is_expected.to eq(true) }
-    end
-  end
-
   describe "filter" do
     let(:filtered) { Kiev::Config.instance.filtered_params }
     let(:ignored) { Kiev::Config.instance.ignored_params }


### PR DESCRIPTION
This brings back previous behavior allowing a string as `Kiev#event` second argument, as suggested in the [README](https://github.com/blacklane/kiev#other-events) other events section.