### PR TITLE
Enhance 'ContextReader' for a 'tracking_id' check.

### DIFF
--- a/lib/kiev/context_reader.rb
+++ b/lib/kiev/context_reader.rb
@@ -19,7 +19,7 @@ module Kiev
     end
 
     def tracking_id
-      self[TRACKING_ID] || self[REQUEST_ID] || SecureRandom.uuid
+      presence(self[TRACKING_ID]) || presence(self[REQUEST_ID]) || SecureRandom.uuid
     end
 
     alias_method :request_id, :tracking_id
@@ -43,5 +43,9 @@ module Kiev
     private
 
     attr_reader :subject
+
+    def presence(value)
+      return value if value && !value.empty?
+    end
   end
 end

--- a/lib/kiev/version.rb
+++ b/lib/kiev/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kiev
-  VERSION = "4.8.2"
+  VERSION = "4.8.3"
 end

--- a/spec/lib/kiev/rack/request_id_spec.rb
+++ b/spec/lib/kiev/rack/request_id_spec.rb
@@ -58,6 +58,17 @@ if defined?(Rack)
           expect(Kiev::RequestStore.store[:tracking_id]).to eq("a" * 255)
         end
       end
+
+      context "when there is a X-Request-Id set to an empty string" do
+        before { header("X-Request-Id", "") }
+        it do
+          expect(Kiev::RequestStore.store[:request_id]).to eq(nil)
+          expect(subject.headers["X-Request-Id"]).not_to eq("")
+          expect(subject.headers["X-Tracking-Id"]).not_to eq("")
+          expect(Kiev::RequestStore.store[:request_id]).not_to eq("")
+          expect(Kiev::RequestStore.store[:tracking_id]).not_to eq("")
+        end
+      end
     end
 
     describe "X-Tracking-Id" do

--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -94,6 +94,14 @@ if defined?(Sidekiq)
       assert_nil(Kiev::RequestStore.store[:tracking_id])
     end
 
+    it "server middleware provides a value if existing request_id is an empty string" do
+      run_sidekiq("request_id" => "")
+      refute_empty(log_first["request_id"])
+      refute_empty(log_first["tracking_id"])
+      assert_nil(Kiev::RequestStore.store[:request_id])
+      assert_nil(Kiev::RequestStore.store[:tracking_id])
+    end
+
     it "server middleware generates new request_id each time" do
       run_sidekiq
       run_sidekiq


### PR DESCRIPTION
* Apply `presence` to avoid false-positive checks with an empty string.

### Context

An empty string is considered to be a *present* value, but it does not carry any meaning and may even be invalid in certain contexts such as SNS message attributes (where empty value strings are not allowed).

In this case the `ContextReader` should assign the request a new ID, but because the current check relies on Ruby's notion of "truthiness", an empty string passes as a valid ID.

This fix remediates the issue by adding `.empty?` to the check.