### PR TITLE
[TEAM-118] Extract dependency license policy into dedicated Claude skill

### DIFF
--- a/.claude.sample/skills/dependency-license-check/SKILL.md
+++ b/.claude.sample/skills/dependency-license-check/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: dependency-license-check
+description: Validates dependency licenses against Blacklane's Open Source Software Policy before adding any new library. Use when installing, adding, or upgrading dependencies in any language.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - WebFetch
+---
+
+# Dependency & License Compliance
+
+Ensure every dependency in the project complies with Blacklane's [Open Source Software Policy](https://blacklane.atlassian.net/wiki/spaces/PT/pages/5525078029). Write original code where possible; when a library is needed, verify it carries a permissive license before adding it.
+
+## When to Use
+
+**MANDATORY** — Always invoke this skill before:
+- Adding any new dependency
+- Upgrading an existing dependency to a new major version
+- Any task that results in a new entry in a dependency file
+
+
+**Language-specific install commands this covers:**
+- `bundle add`, `gem install` — adds to `Gemfile`
+
+**Always run this check first — then add the library.**
+
+Also invoke this skill when:
+- User asks to "check licenses", "audit dependencies", or "verify compliance" of existing libraries
+- User asks to evaluate whether a specific library is allowed
+- Reviewing a PR that introduces new dependencies
+
+## Validation Workflow
+
+1. **Identify the dependency** — Name, version, and language ecosystem
+2. **Verify the license** — Confirm it is on the approved list (see `license-policy.md`)
+3. **Determine usage context** — Production runtime vs dev/test/CI only (see `usage-detection.md`)
+4. **Confirm compliance** — Match license + usage context against the policy matrix
+5. **Report** — Tell the user the license, context, and compliance status
+
+## Approved Licenses (use these freely)
+
+**Any context:** MIT, Apache-2.0, BSD, ISC, MPL-2.0
+**Dev/test/CI tooling only:** LGPL, GPL, AGPL (standalone binary/CLI only)
+
+Libraries with unknown, missing, or custom licenses require a waiver — see `license-policy.md` for the full matrix and waiver process.
+
+## Output
+
+Report to the user:
+- Dependency name and version
+- Detected license
+- Whether it's production or dev/test usage
+- Compliant / Not compliant / Needs waiver
+- If not compliant: suggest permissive-licensed alternatives or the waiver process
+
+## Examples
+
+```
+User: "Add github.com/some/library to handle CSV parsing"
+
+1. Verify license -> MIT (permissive)
+2. Determine usage -> Production (imported in non-test Go files)
+3. MIT + Production -> Compliant
+
+github.com/some/library (MIT) is approved for production use.
+```
+
+```
+User: "Add a GPL-licensed linter tool"
+
+1. Verify license -> GPL-3.0
+2. Determine usage -> Dev/CI only (standalone CLI binary)
+3. GPL-3.0 + standalone dev tool -> Compliant
+
+Approved as a standalone dev/CI tool (not compiled into the production binary).
+```
+
+```
+User: "I need a library for X" (and it has a restrictive license)
+
+1. Verify license -> AGPL-3.0
+2. Determine usage -> Production (imported in Go service)
+3. AGPL-3.0 + Production -> Not compliant
+
+-> Suggest permissive alternatives for X, or write an original implementation.
+-> If no alternative exists, direct user to the Legal service desk for a waiver.
+```
+
+## Code Originality
+
+For complex logic (SQL queries, regex patterns, algorithms), prefer writing original implementations tailored to our domain. When referencing external patterns, ensure they come from permissive-licensed sources and adapt them to our codebase rather than copying verbatim.
+
+## Supporting Files
+
+- `license-policy.md` — Full license compatibility matrix, Wiz SBOM verification, and rules
+- `usage-detection.md` — How to determine production vs dev/test usage per language

--- a/.claude.sample/skills/dependency-license-check/license-policy.md
+++ b/.claude.sample/skills/dependency-license-check/license-policy.md
@@ -1,0 +1,73 @@
+# License Policy
+
+All new dependencies must comply with Blacklane's [Open Source Software Policy](https://blacklane.atlassian.net/wiki/spaces/PT/pages/5525078029).
+
+## Allowed Licenses (no approval needed)
+
+| License | Production runtime | Dev / test / CI tooling |
+|---|---|---|
+| MIT, Apache-2.0, BSD, ISC | Yes | Yes |
+| MPL-2.0 | Yes (don't modify MPL files) | Yes |
+
+## Restricted Licenses
+
+| License | Production runtime | Dev / test / CI tooling |
+|---|---|---|
+| LGPL-2.1 / LGPL-3.0 | **No** for compiled backends (Go, Rust, Java, Kotlin), mobile (Swift), bundled JS. Legacy only. | Yes (standalone binary/CLI only) |
+| GPL-2.0 / GPL-3.0 | **No** — do not introduce new GPL runtime deps | Yes (standalone binary/CLI only) |
+| AGPL-3.0 | **Hard no** | Yes (standalone internal CLI only) |
+| Unknown / no license / custom | **Hard no** | **Hard no** |
+
+## Key Rules
+
+- **Production vs dev/test distinction matters.** GPL/LGPL/AGPL tools used as standalone executables in dev, CI, or tests (linters, compilers, CLIs) are fine. The same licenses are prohibited as linked runtime dependencies in shipped code.
+- **No license = no permission.** Treat code with no LICENSE file as proprietary.
+- If you need a restricted-license dependency, a waiver is required via the [Legal service desk](https://blacklane.atlassian.net/servicedesk/customer/portal/26). Inform your EM or Staff Engineer.
+- Keep all LICENSE / NOTICE files when vendoring dependencies.
+- When in doubt, ask before adding the dependency.
+
+## How to Check a License
+
+### Ruby
+```bash
+# Check via RubyGems
+gem specification <gem_name> license
+# Or check the gem's page on rubygems.org
+# Or inspect the LICENSE file in the gem's GitHub repo
+```
+
+## Wiz License Verification (MANDATORY for new dependencies)
+
+When adding any new dependency (direct or indirect), you **must** verify its license and the licenses of its transitive dependencies using the Wiz MCP SBOM tool before proceeding. CI/CD will block PRs that introduce restrictive-licensed production dependencies.
+
+### Process for every new dependency
+
+1. **Before installing**, query `mcp__wiz__list_sbom` with the package name to check its license and Wiz category.
+2. **Check transitive dependencies too.** After adding the dependency, check the dependency lock file for any new transitive deps and query those as well. Restrictive-licensed transitive deps will also be flagged by CI/CD.
+3. **Evaluate the Wiz license category:**
+   - **Permissive** — safe to use, proceed.
+   - **Semi-Permissive** (e.g., MPL-2.0) — allowed for production if MPL files are not modified. Proceed with caution.
+   - **Restrictive** (e.g., GPL, AGPL, LGPL) — **block the install** unless the dependency is a standalone dev/CI tool (not compiled into the production binary). Inform the user that CI/CD will reject the PR.
+   - **Unknown** — **block the install**. No license = no permission.
+4. **If a restrictive-licensed dependency is detected:**
+   - Stop the installation and revert the dependency change.
+   - Inform the user which packages have restrictive licenses and why they are blocked.
+   - Suggest permissive-licensed alternatives if known.
+   - If a waiver is needed, direct the user to the [Legal service desk](https://blacklane.atlassian.net/servicedesk/customer/portal/26).
+
+### Example Wiz SBOM check
+
+```
+mcp__wiz__list_sbom(name_filter: ["github.com/example/package"], limit: 10)
+```
+Look at the `licenses` array in the response — each license has an `id` (e.g., "MIT", "GPL-3.0-only") and `categories` with a category `id` ("permissive", "semi-permissive", or "restrictive").
+
+**Note:** If the Wiz MCP server is unavailable, fall back to checking the license on the package's GitHub/source repository and apply the Allowed/Restricted license tables above manually.
+
+## Wiz CI/CD Scanning
+
+Wiz scans detect restrictive licenses in CI/CD. Two scan types exist:
+- **PR scans** - Only scan changed files (diff-based). Will NOT catch pre-existing license issues.
+- **Full repository scans** - Scan everything. Run via Wiz portal ("User Initiated").
+
+If Wiz flags a dependency with a restrictive license (e.g., GPL-3.0-only), verify whether it's a production or dev/test dependency before taking action.

--- a/.claude.sample/skills/dependency-license-check/usage-detection.md
+++ b/.claude.sample/skills/dependency-license-check/usage-detection.md
@@ -1,0 +1,51 @@
+# Usage Detection: Production vs Dev/Test
+
+How to determine whether a dependency is used in production runtime or only in dev/test/CI.
+
+
+## Dependency Files by Language
+- **Ruby:** `Gemfile`, `Gemfile.lock`
+
+---
+## Ruby
+
+- Default group in `Gemfile` -> **Production** (loaded at runtime)
+- `:development`, `:test` groups -> **Dev/test only**
+
+```ruby
+# Gemfile — production gem
+gem 'rails'
+gem 'pg'
+
+# Gemfile — dev/test only
+group :development, :test do
+  gem 'rspec-rails'
+  gem 'rubocop'
+end
+```
+
+**Check which group a gem belongs to:**
+```bash
+# Look at the Gemfile directly
+grep '<gem_name>' Gemfile
+# Check if the gem is in a dev/test group
+grep -A2 'group :development' Gemfile | grep '<gem_name>'
+grep -A2 'group :test' Gemfile | grep '<gem_name>'
+```
+
+**When installing**, always add to the correct group:
+- `bundle add <gem>` -> adds to default group (production)
+- `bundle add <gem> --group development,test` -> adds to dev/test group
+
+**Common dev/test gems** (should NOT be in default group): rspec, rubocop, pry, byebug, factory_bot, faker, simplecov, webmock, vcr.
+
+**Note:** Bundler's `require: false` does NOT make a gem dev-only — it just prevents auto-require. The group determines production vs dev/test.
+
+---
+
+## Standalone Binaries vs Linked Libraries
+
+For restricted licenses (GPL/LGPL/AGPL), the distinction between standalone binaries and linked libraries matters:
+
+- **Standalone binary/CLI** (e.g., a linter, formatter, compiler): Runs as a separate process. Not linked into our code. **Allowed in dev/CI.**
+- **Linked library** (e.g., imported Go package, npm dependency bundled in build, Gradle `implementation` dep, SPM linked target): Compiled/bundled into our application. **Restricted in production.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,12 @@ Kiev uses three key concepts for distributed tracing:
 - LogHelper module provides `logs`, `log_first`, `log_last` helpers for parsing JSON logs
 - Integration tests use real framework instances (Combustion for Rails, test apps for Sinatra)
 - Sidekiq tests handle version differences (6.4 vs 6.5+) where BasicFetch was removed
+
+## Code Originality & Compliance
+
+When writing code, always implement novel solutions: create new code from scratch or import a compliant library.
+Use the `dependency-license-check` skill to verify any library meets our standards before adding it. For complex logic (SQL queries, regex patterns, algorithms), write original implementations tailored to our domain rather than reproducing snippets from external sources with restrictive licensing or use a library that meets our licensing standards.
+
+## Dependency & License Policy
+
+All new dependencies must comply with Blacklane's Open Source Software Policy. **You MUST invoke the `dependency-license-check` skill before adding, installing, or upgrading any dependency. Never add a library without running this check first.** The skill is also used when auditing existing dependencies for compliance. See the `dependency-license-check` skill files for the complete policy, allowed/restricted license matrix, and per-language usage detection rules.


### PR DESCRIPTION
## Summary
- Extracts the inline dependency & license policy from CLAUDE.md into a dedicated `dependency-license-check` skill
- The skill is mandatory before adding, installing, or upgrading any dependency
- Adds "Code Originality & Compliance" section to CLAUDE.md
- Includes Wiz MCP SBOM verification, license matrix, and per-language usage detection
- Language-specific sections are automatically selected based on detected languages

## Context
The license policy in CLAUDE.md was ~60 lines of tables and rules that cluttered the file. Moving it to a skill:
- Keeps CLAUDE.md lean and focused
- Ensures the check is consistently invoked via Claude's skill system
- Makes the policy easier to maintain and extend independently
- Adds support for auditing existing deps (not just new ones)

## What's in the skill
- `SKILL.md` — Trigger conditions, validation workflow, examples
- `license-policy.md` — Allowed/restricted license matrix, Wiz SBOM verification process, CI/CD scanning notes
- `usage-detection.md` — How to determine production vs dev/test usage per language

**Note:** The skill files live in `.claude.sample/skills/` (or `.claude/skills/`) which may be gitignored — they are local Claude Code config. Only the CLAUDE.md reference is committed.

## Test plan
- [ ] Verify CLAUDE.md has the short policy reference (not verbose tables)
- [ ] Verify "Code Originality & Compliance" section is present
- [ ] Verify skill files contain only relevant language sections
- [ ] Verify the skill is invoked when attempting to add a new dependency